### PR TITLE
Rename `_transferUsdtIntoRedPacket` to `_transferERC20IntoRedPacket` for clarity

### DIFF
--- a/src/RedPacket.sol
+++ b/src/RedPacket.sol
@@ -49,7 +49,7 @@ contract RedPacket is IRedPacket {
         returns (address walletContract)
     {
         walletContract = factory.createRedPacket(_recipient);
-        _transferUsdtIntoRedPacket(walletContract, _erc20, _amount);
+        _transferERC20IntoRedPacket(walletContract, _erc20, _amount);
         emit RedPacketCreated(walletContract, _recipient, _erc20, _amount);
     }
 
@@ -61,7 +61,7 @@ contract RedPacket is IRedPacket {
     /// @param _nftWallet The address of the red packet wallet
     /// @param _erc20 The address of the ERC20 token to be transferred
     /// @param _amount The amount of ERC20 tokens to be transferred
-    function _transferUsdtIntoRedPacket(address _nftWallet, address _erc20, uint256 _amount) internal {
+    function _transferERC20IntoRedPacket(address _nftWallet, address _erc20, uint256 _amount) internal {
         bool success = IERC20(_erc20).transferFrom(msg.sender, _nftWallet, _amount);
         if (!success) revert RedPacket__TransferFailed();
     }


### PR DESCRIPTION
Rename `_transferUsdtIntoRedPacket` to `_transferERC20IntoRedPacket` for clarity

- Updated the internal function name from `_transferUsdtIntoRedPacket` to `_transferERC20IntoRedPacket` to better reflect its functionality, which handles the transfer of any ERC20 token, not just USDT.
- Ensured that method name accurately describes its purpose and avoids confusion."
